### PR TITLE
add hover label format for cases where the date could use more context

### DIFF
--- a/lib/morris.grid.coffee
+++ b/lib/morris.grid.coffee
@@ -83,6 +83,7 @@ class Morris.Grid extends Morris.EventEmitter
     @data = for row, index in data
       ret = {}
       ret.label = row[@options.xkey]
+      ret.originalData = row
       if @options.parseTime
         ret.x = Morris.parseDate(ret.label)
         if @options.dateFormat

--- a/lib/morris.line.coffee
+++ b/lib/morris.line.coffee
@@ -54,6 +54,7 @@ class Morris.Line extends Morris.Grid
     hideHover: false
     xLabels: 'auto'
     xLabelFormat: null
+    hoverLabelFormat: (label, originalData) -> label
 
   # Do any size-related calculations
   #
@@ -222,7 +223,7 @@ class Morris.Line extends Morris.Grid
   updateHover: (index) =>
     @hoverSet.show()
     row = @data[index]
-    @xLabel.attr('text', row.label)
+    @xLabel.attr('text', @options.hoverLabelFormat(row.label, row.originalData))
     for y, i in row.y
       @yLabels[i].attr('text', "#{@options.labels[i]}: #{@yLabelFormat(y)}")
     # recalculate hover box width


### PR DESCRIPTION
In my case, I'm averaging data for the last 10 dates and then graphing that data.  In the hover I'd like to have a date range as the label (3/24/2012 - 4/5/2012) as it contextualizes the data more accurately.  

In order to achieve this, I added an 'originalData' field to each element in the internal data variable (@data).  Having access to the original data point provides a lot of flexibility, as the data point could be defined as {x: '2012-04-05', y: 25, description: 'anything I want', start_date: '2012-03-24' } 

Thanks for putting this graph together.  In my opinion its a great looking graph and easy to modify/use!
