### PR TITLE
Allow to fully disable hover legend on line, area and bar grpahs

### DIFF
--- a/lib/morris.bar.coffee
+++ b/lib/morris.bar.coffee
@@ -161,6 +161,7 @@ class Morris.Bar extends Morris.Grid
 
   # @private
   updateHover: (index) =>
+    return if @options.disableLegend
     @hoverSet.show()
     row = @data[index]
     @xLabel.attr('text', row.label)

--- a/lib/morris.line.coffee
+++ b/lib/morris.line.coffee
@@ -234,6 +234,7 @@ class Morris.Line extends Morris.Grid
 
   # @private
   updateHover: (index) =>
+    return if @options.disableLegend
     @hoverSet.show()
     row = @data[index]
     @xLabel.attr('text', row.label)


### PR DESCRIPTION
When you need to completely hide hover legend you can pass `disableLegend: true` option when you create the chart
