### PR TITLE
Allow Donut to handle PHP json_encode output

### DIFF
--- a/morris.js
+++ b/morris.js
@@ -1391,7 +1391,7 @@
       _ref = this.data;
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
         x = _ref[_i];
-        total += x.value;
+        total += parseFloat(x.value);
       }
       min = 5 / (2 * w);
       C = 1.9999 * Math.PI - min * this.data.length;


### PR DESCRIPTION
Currently, Morris.Donut produces a chart with a load of tiny little bars on the bottom right of donut charts generated from data straight from PHP's json_encode function.

The other chart types don't do this, because they parse the values into Int/Float values.

This change adds "parseFloat" to the line of the Donut code which reads the x.value, which brings it into line with the other chart methods, and makes json_encode output work as expected

It also has a longer commit summary than the amount of code added...
