### PR TITLE
Fixes #186 - changed CSS top value for hover to be an int

### DIFF
--- a/lib/morris.hover.coffee
+++ b/lib/morris.hover.coffee
@@ -32,7 +32,7 @@ class Morris.Hover
           top = parentHeight / 2 - hoverHeight / 2
     else
       top = parentHeight / 2 - hoverHeight / 2
-    @el.css(left: left + "px", top: top + "px")
+    @el.css(left: left + "px", top: parseInt(top) + "px")
 
   show: ->
     @el.show()


### PR DESCRIPTION
I was able to replicate #186 in Chrome 27 on Linux. This fixed it for me.
