### PR TITLE
Update to Line/Bar.prototype.onHoverOut

### DIFF
--- a/morris.js
+++ b/morris.js
@@ -738,7 +738,7 @@
     };
 
     Line.prototype.onHoverOut = function() {
-      if (this.options.hideHover === 'auto') {
+      if (this.options.hideHover !== false) {
         return this.displayHoverForRow(null);
       }
     };
@@ -1436,7 +1436,7 @@
     };
 
     Bar.prototype.onHoverOut = function() {
-      if (this.options.hideHover === 'auto') {
+      if (this.options.hideHover !== false) {
         return this.hover.hide();
       }
     };


### PR DESCRIPTION
I have never edited/contributed to a Repo before so I hope I don't cause World War 3 somehow.

I just found Morris.js yesterday, and while I was testing it out I noticed that my chart legend remained displayed after my mouse left the chart area.

After looking at the source code, I believe both Line/Bar.prototype.onHoverOut should be changed to !== false.  I tested this problem/change on Mac OS using latest versions of Chrome, Firefox, Safari and Opera.  Problem ceased to exist in all browsers after my change from === 'auto' to !== false
