### PR TITLE
Update Developer Quickstart instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You'll need [node.js](https://nodejs.org).  I recommend using
 development environments.
 
 With node installed, install [grunt](https://github.com/cowboy/grunt) using
-`npm install -g grunt`, and then the rest of the test/build dependencies
+`npm install -g grunt-cli`, and then the rest of the test/build dependencies
 with `npm install` in the morris.js project folder.
 
 Once you're all set up, you can compile, minify and run the tests using `grunt`.


### PR DESCRIPTION
I'm a node/js newbie, but I believe my change is the current way to install grunt. I stumbled for a while trying to follow the instructions until I went to the grunt website.
