### PR TITLE
pointSize attribute should accept an array of values

### DIFF
--- a/lib/morris.line.coffee
+++ b/lib/morris.line.coffee
@@ -7,8 +7,11 @@ class Morris.Line extends Morris.Grid
 
   init: ->
     # Some instance variables for later
-    @pointGrow = Raphael.animation r: @options.pointSize + 3, 25, 'linear'
-    @pointShrink = Raphael.animation r: @options.pointSize, 25, 'linear'
+    @pointGrow = []
+    @pointShrink = []
+    for pointSize in @options.pointSizes
+      @pointGrow.push Raphael.animation r: pointSize + 3, 25, 'linear'
+      @pointShrink.push Raphael.animation r: pointSize, 25, 'linear'
 
     if @options.hideHover isnt 'always'
       @hover = new Morris.Hover(parent: @el)
@@ -20,7 +23,7 @@ class Morris.Line extends Morris.Grid
   #
   defaults:
     lineWidth: 3
-    pointSize: 4
+    pointSizes: [4]
     lineColors: [
       '#0b62a4'
       '#7A92A3'
@@ -198,7 +201,7 @@ class Morris.Line extends Morris.Grid
     for row in @data
       circle = null
       if row._y[index]?
-        circle = @drawLinePoint(row._x, row._y[index], @options.pointSize, @colorFor(row, index, 'point'), index)
+        circle = @drawLinePoint(row._x, row._y[index], @options.pointSizes[index % @options.pointSizes.length], @colorFor(row, index, 'point'), index)
       @seriesPoints[index].push(circle)
 
   _drawLineFor: (index) ->
@@ -259,11 +262,11 @@ class Morris.Line extends Morris.Grid
     if @prevHilight isnt null and @prevHilight isnt index
       for i in [0..@seriesPoints.length-1]
         if @seriesPoints[i][@prevHilight]
-          @seriesPoints[i][@prevHilight].animate @pointShrink
+          @seriesPoints[i][@prevHilight].animate @pointShrink[i]
     if index isnt null and @prevHilight isnt index
       for i in [0..@seriesPoints.length-1]
         if @seriesPoints[i][index]
-          @seriesPoints[i][index].animate @pointGrow
+          @seriesPoints[i][index].animate @pointGrow[i]
     @prevHilight = index
 
   colorFor: (row, sidx, type) ->

--- a/spec/lib/line/line_spec.coffee
+++ b/spec/lib/line/line_spec.coffee
@@ -181,6 +181,7 @@ describe 'Morris.Line', ->
       gridStrokeWidth: 0.5
       gridTextColor: '#888'
       gridTextSize: 12
+      pointSizes: [5]
 
     it 'should have circles with configured fill color', ->
       chart = Morris.Line $.extend {}, defaults
@@ -205,3 +206,7 @@ describe 'Morris.Line', ->
     it 'should have text with configured font size', ->
       chart = Morris.Line $.extend {}, defaults
       $('#graph').find("text[fill='#888888']").size().should.equal 9
+
+    it 'should have circle with configured size', ->
+      chart = Morris.Line $.extend {}, defaults
+      $('#graph').find("circle[r='5']").size().should.equal 2


### PR DESCRIPTION
- the purpose is to be able to specify different point size
- pointSize attribute has been renamed pointSizes since it's now an array
