### PR TITLE
feature: configurable vertical segments

### DIFF
--- a/lib/morris.bar.coffee
+++ b/lib/morris.bar.coffee
@@ -109,6 +109,9 @@ class Morris.Bar extends Morris.Grid
           left += sidx * (barWidth + @options.barGap) unless @options.stacked
           size = bottom - top
 
+          if @options.verticalGridCondition and @options.verticalGridCondition(row.x)
+            @drawBar(@left + idx * groupWidth, @top, groupWidth, Math.abs(@top - @bottom), @options.verticalGridColor, @options.verticalGridOpacity, @options.barRadius)
+
           top -= lastTop if @options.stacked
           @drawBar(left, top, barWidth, size, @colorFor(row, sidx, 'bar'),
               @options.barOpacity, @options.barRadius)

--- a/spec/lib/bar/bar_spec.coffee
+++ b/spec/lib/bar/bar_spec.coffee
@@ -1,4 +1,33 @@
 describe 'Morris.Bar', ->
+  describe 'when using vertical grid', ->
+    defaults =
+      element: 'graph'
+      data: [{x: 'foo', y: 2, z: 3}, {x: 'bar', y: 4, z: 6}]
+      xkey: 'x'
+      ykeys: ['y', 'z']
+      labels: ['Y', 'Z']
+      barColors: [ '#0b62a4', '#7a92a3']
+      gridLineColor: '#aaa'
+      gridStrokeWidth: 0.5
+      gridTextColor: '#888'
+      gridTextSize: 12
+      verticalGridCondition: (index) -> index % 2
+      verticalGridColor: '#888888'
+      verticalGridOpacity: '0.2'
+
+    describe 'svg structure', ->
+      it 'should contain extra rectangles for vertical grid', ->
+        $('#graph').css('height', '250px').css('width', '800px')
+        chart = Morris.Bar $.extend {}, defaults
+        $('#graph').find("rect").size().should.equal 6
+
+    describe 'svg attributes', ->
+      it 'should have to bars with verticalGrid.color', ->
+        chart = Morris.Bar $.extend {}, defaults
+        $('#graph').find("rect[fill='#{defaults.verticalGridColor}']").size().should.equal 2
+      it 'should have to bars with verticalGrid.color', ->
+        chart = Morris.Bar $.extend {}, defaults
+        $('#graph').find("rect[fill-opacity='#{defaults.verticalGridOpacity}']").size().should.equal 2
 
   describe 'svg structure', ->
     defaults =


### PR DESCRIPTION
Add ability to create vertical grid.
Screenshot of resulting chart:
[![Screenshot](https://drive.google.com/uc?export=view&id=0B65dEGRmB3ViaHA5U2JERHFmYkE)](https://docs.google.com/file/d/0B65dEGRmB3ViaHA5U2JERHFmYkE/edit)
With next element added to config object:

```
...
        verticalGrid: {
          condition: function(index) {
            return index % 2
          },
          color: '#888',
          opacity: '0.2'
        }
...
```
