### PR TITLE
update npm test task

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "grunt-contrib-watch": "~0.5.3"
   },
   "scripts": {
-    "test": "grunt coffee mocha"
+    "test": "grunt concat coffee mocha"
   },
   "engines": {
     "node": ">=0.8 <0.11"


### PR DESCRIPTION
Overlooked that Travis CI was warning about empty output file when running 'coffee' task with 0/0 passing specs. Not sure, how tests were running before this on Travis.
