### PR TITLE
feature/static labels

### DIFF
--- a/lib/morris.bar.coffee
+++ b/lib/morris.bar.coffee
@@ -107,6 +107,8 @@ class Morris.Bar extends Morris.Grid
           left += sidx * (barWidth + @options.barGap) unless @options.stacked
           size = bottom - top
 
+          if opts = @options?.staticLabels
+            @drawXAxisLabel(left + barWidth / 2, top - (opts.margin or 0), @labelContentForRow(idx))
           top -= lastTop if @options.stacked
           @drawBar(left, top, barWidth, size, @colorFor(row, sidx, 'bar'))
 
@@ -173,6 +175,15 @@ class Morris.Bar extends Morris.Grid
       content = @options.hoverCallback(index, @options, content)
     x = @left + (index + 0.5) * @width / @data.length
     [content, x]
+
+  labelContentForRow: (index) ->
+    row = @data[index]
+    content = ''
+    for y, j in row.y
+      content += "#{@options.labels[j]}:#{@yLabelFormat(y)} "
+    if typeof @options.staticLabels.labelCallback is 'function'
+      content = @options.staticLabels.labelCallback(index, @options, content)
+    content
 
   drawXAxisLabel: (xPos, yPos, text) ->
     label = @raphael.text(xPos, yPos, text)

--- a/spec/lib/bar/bar_spec.coffee
+++ b/spec/lib/bar/bar_spec.coffee
@@ -48,3 +48,33 @@ describe 'Morris.Bar', ->
     it 'should have text with configured font size', ->
       chart = Morris.Bar $.extend {}, defaults
       $('#graph').find("text[font-size='12px']").size().should.equal 7
+
+  describe 'when enabling static labels', ->
+    describe 'svg structure', ->
+      defaults =
+        element: 'graph'
+        data: [{x: 'foo', y: 2, z: 3}, {x: 'bar', y: 4, z: 6}]
+        xkey: 'x'
+        ykeys: ['y', 'z']
+        labels: ['Y', 'Z']
+        staticLabels:
+          margin: 20
+          labelCallback: (index, options, label) ->
+            label + ' km'
+
+      it 'should have extra text nodes', ->
+        chart = Morris.Bar $.extend {}, defaults
+        $('#graph').find("text").size().should.equal 11
+
+      describe 'should have needed text', ->
+        it 'given custom labelCallback', ->
+          chart = Morris.Bar $.extend {}, defaults
+          $('#graph').find("text").filter($("#graph").find("text").filter (index, el) -> $(el).text().match /km$/).size().should.equal 4
+
+        it 'without labelCallback', ->
+          delete defaults.staticLabels
+          chart = Morris.Bar $.extend {
+            staticLabels:
+              margin: 20
+          }, defaults
+          $('#graph').find("text").filter($("#graph").find("text").filter (index, el) -> $(el).text().match /Y\:\d\sZ\:\d/).size().should.equal 4


### PR DESCRIPTION
Feature to add static labels on top of bars.
Allowing callback for content of label:
![morris_static_label_callback](https://f.cloud.github.com/assets/1506905/1369097/58b097de-39d5-11e3-9274-6c7a9a3c46ca.png)

```
...
        labels: ['Distance of'],
        staticLabels: {
            margin: 20,
            labelCallback: function(value, options, label) {
                console.log(arguments)
                return label + ' km'
            }
        },
...
```

![morris_no_static_label_callback](https://f.cloud.github.com/assets/1506905/1369098/597967f4-39d5-11e3-8dcf-2893156b0207.png)

```
...
  labels: ['Y', 'Z'],
  staticLabels: {
    margin: 20
  },
...
```
