### PR TITLE
feature: option to set padding for x axis label

### DIFF
--- a/lib/morris.bar.coffee
+++ b/lib/morris.bar.coffee
@@ -56,7 +56,7 @@ class Morris.Bar extends Morris.Grid
   # @private
   drawXAxis: ->
     # draw x axis labels
-    ypos = @bottom + (@options.xAxisLabelPadding || @options.padding / 2)
+    ypos = @bottom + (@options.xAxisLabelTopPadding || @options.padding / 2)
     prevLabelMargin = null
     prevAngleMargin = null
     for i in [0...@data.length]


### PR DESCRIPTION
Provide ability to set padding option (use case: high labels - multiline, for example, used with big padding will waste a lot of space unless you can specify label padding).
