### PR TITLE
Force morris to use only integer values on Y axis

### DIFF
--- a/morris.js
+++ b/morris.js
@@ -318,7 +318,7 @@
         } else {
           step = (this.ymax - this.ymin) / (this.options.numLines - 1);
           if (this.options.gridIntegers) {
-            step = Math.round(step);
+            step = Math.max(1, Math.round(step));
           }
           this.grid = (function() {
             var _i, _ref1, _ref2, _results;


### PR DESCRIPTION
New option gridIntegers was added to force morris to use only integer numbers on the Y axis. gridIntegers accepts a boolean value (false=default). When set to true, morris will use only integer values on the Y axis.
