### PR TITLE
Update copyright year in license to 2014

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ tests currently *only* pass on OS X.
 
 ## License
 
-Copyright (c) 2014, Olly Smith
+Copyright (c) 2012-2014, Olly Smith
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Noticed the license was still showing 2012 - just updated it to 2014.
