### PR TITLE
Feature: 'Rotate' option for Morris.Donut

### DIFF
--- a/lib/morris.donut.coffee
+++ b/lib/morris.donut.coffee
@@ -24,6 +24,7 @@ class Morris.Donut extends Morris.EventEmitter
     ],
     backgroundColor: '#FFFFFF', 
     labelColor: '#000000',
+    rotate: 0,
     formatter: Morris.commas
     resize: false
 
@@ -69,7 +70,7 @@ class Morris.Donut extends Morris.EventEmitter
     min = 5 / (2 * w)
     C = 1.9999 * Math.PI - min * @data.length
 
-    last = 0
+    last = (this.options.rotate / 180) / Math.PI
     idx = 0
     @segments = []
     for value, i in @values


### PR DESCRIPTION
I added an option to Morris.Donut to rotate DonutsSegments. The option is named 'rotate', and the input range is 0-360. I'm using a rotating Donut to visualize a timer, inspired by those simple mechanical 24-hour outlet timers used to control lights and other electronics, but there are probably other uses.
