### PR TITLE
Fix hideHover never show value

### DIFF
--- a/bars.html
+++ b/bars.html
@@ -87,10 +87,10 @@ morris_version: 0.5.1
           <td>
             Set to <code>false</code> to always show a hover legend.
             <br>
-            Set to <code>'auto'</code> to only show the hover legend when the
-            mouse cursor is over the chart.
+            Set to <code>true</code> or <code>'auto'</code> to only show the
+            hover legend when the mouse cursor is over the chart.
             <br>
-            Set to <code>true</code> to never show a hover legend.
+            Set to <code>'always'</code> to never show a hover legend.
           </td>
         </tr>
         <tr>


### PR DESCRIPTION
Fixes #445.

Basically copied from `lines.html` which fixes documentation of `hideHover` option
