### PR TITLE
Don't grow a point if its size is 0

### DIFF
--- a/lib/morris.line.coffee
+++ b/lib/morris.line.coffee
@@ -311,6 +311,8 @@ class Morris.Line extends Morris.Grid
 
   # @private
   pointGrowSeries: (index) ->
+    if @pointSizeForSeries(index) is 0
+      return
     Raphael.animation r: @pointSizeForSeries(index) + 3, 25, 'linear'
 
   # @private


### PR DESCRIPTION
If you don't want a point it should not appear when you hover over it. Maybe it should be changed to a false flag just as in #448. Let me know what you think. 

In my opinion zero seems fair, the point you get when it gets larger is smaller than the actual line.
