### PR TITLE
Add feature to not show certain plots, but still show values in the legend

### DIFF
--- a/lib/morris.bar.coffee
+++ b/lib/morris.bar.coffee
@@ -29,6 +29,7 @@ class Morris.Bar extends Morris.Grid
     barOpacity: 1.0
     barRadius: [0, 0, 0, 0]
     xLabelMargin: 50
+    shown: true
 
   # Do any size-related calculations
   #
@@ -90,7 +91,14 @@ class Morris.Bar extends Morris.Grid
   # @private
   drawSeries: ->
     groupWidth = @width / @options.data.length
-    numBars = if @options.stacked then 1 else @options.ykeys.length
+    if @options.stacked
+      numBars = 1
+    else
+      numBars = 0
+      for i in [0..@options.ykeys.length]
+        if @hasToShow(i)
+          numBars += 1
+
     barWidth = (groupWidth * @options.barSizeRatio - @options.barGap * (numBars - 1)) / numBars
     barWidth = Math.min(barWidth, @options.barSize) if @options.barSize
     spaceLeft = groupWidth - barWidth * numBars - @options.barGap * (numBars - 1)
@@ -99,6 +107,8 @@ class Morris.Bar extends Morris.Grid
     @bars = for row, idx in @data
       lastTop = 0
       for ypos, sidx in row._y
+        if not @hasToShow(sidx)
+          continue
         if ypos != null
           if zeroPos
             top = Math.min(ypos, zeroPos)

--- a/lib/morris.grid.coffee
+++ b/lib/morris.grid.coffee
@@ -172,7 +172,7 @@ class Morris.Grid extends Morris.EventEmitter
         yval = row[ykey]
         yval = parseFloat(yval) if typeof yval is 'string'
         yval = null if yval? and typeof yval isnt 'number'
-        if yval?
+        if yval? and @hasToShow(idx)
           if @cumulative
             total += yval
           else
@@ -409,6 +409,10 @@ class Morris.Grid extends Morris.EventEmitter
     @timeoutId = null
     @raphael.setSize @el.width(), @el.height()
     @redraw()
+
+  hasToShow: (i) =>
+    @options.shown is true or @options.shown[i] is true
+
 
 # Parse a date into a javascript timestamp
 #

--- a/lib/morris.line.coffee
+++ b/lib/morris.line.coffee
@@ -31,6 +31,7 @@ class Morris.Line extends Morris.Grid
     pointStrokeColors: ['#ffffff']
     pointFillColors: []
     smooth: true
+    shown: true
     xLabels: 'auto'
     xLabelFormat: null
     xLabelMargin: 24
@@ -184,9 +185,12 @@ class Morris.Line extends Morris.Grid
   drawSeries: ->
     @seriesPoints = []
     for i in [@options.ykeys.length-1..0]
-      @_drawLineFor i
+      if @hasToShow(i)
+        @_drawLineFor i
+
     for i in [@options.ykeys.length-1..0]
-      @_drawPointFor i
+      if @hasToShow(i)
+        @_drawPointFor i
 
   _drawPointFor: (index) ->
     @seriesPoints[index] = []


### PR DESCRIPTION
Sometimes you want to see a value that has a relation to the graph data, but the plot for those values is not really relevant.
