### PR TITLE
Pass series index to yLabelFormat

### DIFF
--- a/lib/morris.bar.coffee
+++ b/lib/morris.bar.coffee
@@ -241,7 +241,7 @@ class Morris.Bar extends Morris.Grid
       content += """
         <div class='morris-hover-point' style='color: #{@colorFor(row, j, 'label')}'>
           #{@options.labels[j]}:
-          #{@yLabelFormat(y)}
+          #{@yLabelFormat(y, j)}
         </div>
       """
     if typeof @options.hoverCallback is 'function'

--- a/lib/morris.grid.coffee
+++ b/lib/morris.grid.coffee
@@ -381,13 +381,13 @@ class Morris.Grid extends Morris.EventEmitter
 
   # @private
   #
-  yAxisFormat: (label) -> @yLabelFormat(label)
+  yAxisFormat: (label) -> @yLabelFormat(label, 0)
 
   # @private
   #
-  yLabelFormat: (label) ->
+  yLabelFormat: (label, i) ->
     if typeof @options.yLabelFormat is 'function'
-      @options.yLabelFormat(label)
+      @options.yLabelFormat(label, i)
     else
       "#{@options.preUnits}#{Morris.commas(label)}#{@options.postUnits}"
 

--- a/lib/morris.line.coffee
+++ b/lib/morris.line.coffee
@@ -115,7 +115,7 @@ class Morris.Line extends Morris.Grid
       content += """
         <div class='morris-hover-point' style='color: #{@colorFor(row, j, 'label')}'>
           #{@options.labels[j]}:
-          #{@yLabelFormat(y)}
+          #{@yLabelFormat(y, j)}
         </div>
       """
     if typeof @options.hoverCallback is 'function'


### PR DESCRIPTION
Some of my graphs needed a euro sign prepended and others didn't. This is probably only useful for hidden series, since it would be weird to have multiple types of units in the same plot.
