### PR TITLE
Escape labels in hover

### DIFF
--- a/lib/morris.bar.coffee
+++ b/lib/morris.bar.coffee
@@ -233,7 +233,8 @@ class Morris.Bar extends Morris.Grid
   # @private
   hoverContentForRow: (index) ->
     row = @data[index]
-    content = "<div class='morris-hover-row-label'>#{row.label}</div>"
+    content = $("<div class='morris-hover-row-label'>").text(row.label)
+    content = content.prop('outerHTML')
     for y, j in row.y
       if @options.labels[j] is false
         continue

--- a/lib/morris.line.coffee
+++ b/lib/morris.line.coffee
@@ -107,7 +107,8 @@ class Morris.Line extends Morris.Grid
   # @private
   hoverContentForRow: (index) ->
     row = @data[index]
-    content = "<div class='morris-hover-row-label'>#{row.label}</div>"
+    content = $("<div class='morris-hover-row-label'>").text(row.label)
+    content = content.prop('outerHTML')
     for y, j in row.y
       if @options.labels[j] is false
         continue


### PR DESCRIPTION
Prevents XSS attacks by not concatenating the row label. The row label could contain any value. I'm comparing stats of users for instance, so this wouldn't be safe.
