### PR TITLE
Fix hover positioning for linecharts when some lines are hidden

### DIFF
--- a/lib/morris.line.coffee
+++ b/lib/morris.line.coffee
@@ -59,7 +59,7 @@ class Morris.Line extends Morris.Grid
       row._x = @transX(row.x)
       row._y = for y in row.y
         if y? then @transY(y) else y
-      row._ymax = Math.min [@bottom].concat(y for y in row._y when y?)...
+      row._ymax = Math.min [@bottom].concat(y for y, i in row._y when y? and @hasToShow(i))...
 
   # hit test - returns the index of the row at the given x-coordinate
   #


### PR DESCRIPTION
Plots that are not shown should not count when calculating `_ymax` for a position in the graph.