### PR TITLE
Don't draw a path to null

### DIFF
--- a/lib/morris.line.coffee
+++ b/lib/morris.line.coffee
@@ -129,7 +129,7 @@ class Morris.Line extends Morris.Grid
   generatePaths: ->
     @paths = for i in [0...@options.ykeys.length]
       smooth = if typeof @options.smooth is "boolean" then @options.smooth else @options.ykeys[i] in @options.smooth
-      coords = ({x: r._x, y: r._y[i]} for r in @data when r._y[i] isnt undefined)
+      coords = ({x: r._x, y: r._y[i]} for r in @data when r._y[i]?)
 
       if coords.length > 1
         Morris.Line.createPath coords, smooth, @bottom


### PR DESCRIPTION
Only `undefined` was not drawn in line charts, but `null` shouldn't be drawn either.
