### PR TITLE
Update morris.js

### DIFF
--- a/morris.js
+++ b/morris.js
@@ -581,6 +581,8 @@ Licensed under the BSD-2-Clause License.
     };
 
     Grid.prototype.resizeHandler = function() {
+      if (this.el.width()<1 || this.el.height()<1) return false;
+      
       this.timeoutId = null;
       this.raphael.setSize(this.el.width(), this.el.height());
       return this.redraw();


### PR DESCRIPTION
this skips the redraw if chart container is collapsed. handles the option{resize : true}
it was crashing for me in firefox with multiple views, when some hidden.
did not go too deep with it, quick fix. 
donut works fine. for whatever reason.
