### PR TITLE
Fixes copy&paste error in event

### DIFF
--- a/lib/morris.grid.coffee
+++ b/lib/morris.grid.coffee
@@ -441,7 +441,7 @@ class Morris.Grid extends Morris.EventEmitter
       .attr('stroke-width', @options.goalStrokeWidth)
 
   drawEvent: (event, color) ->
-    x = Math.floor(@transX(goal)) + 0.5
+    x = Math.floor(@transX(event)) + 0.5
     if not @options.horizontal
       path = "M#{x},#{@yStart}V#{@yEnd}"
     else


### PR DESCRIPTION
This was referenced in https://github.com/morrisjs/morris.js/commit/715771431c9b3b8b54a3ebcfc6dc72e7ffa29536
