### PR TITLE
Morris.Bar bar property now holds the bar list

### DIFF
--- a/less/morris.core.less
+++ b/less/morris.core.less
@@ -8,6 +8,8 @@
     color: #666;
     background: rgba(255, 255, 255, 0.8);
     border: solid 2px rgba(230, 230, 230, 0.8);
+    background: white\9;
+    border: solid 2px #ccc\9;
 
     font-family: sans-serif;
     font-size: 12px;

--- a/lib/morris.bar.coffee
+++ b/lib/morris.bar.coffee
@@ -169,13 +169,13 @@ class Morris.Bar extends Morris.Grid
 
           top -= lastTop if @options.stacked
           if not @options.horizontal
+            lastTop += size
             @drawBar(left, top, barWidth, size, @colorFor(row, sidx, 'bar'),
                 @options.barOpacity, @options.barRadius)
-            lastTop += size
           else
+            lastTop -= size
             @drawBar(top, left, size, barWidth, @colorFor(row, sidx, 'bar'),
                 @options.barOpacity, @options.barRadius)
-            lastTop -= size
 
 
         else


### PR DESCRIPTION
The `drawSeries` method assigned a list of residual computation values to the instance's `bars` property. Now the routine populates this property with the list of Raphael.js path objects corresponding to the visualization's bars.