### PR TITLE
Fix label color in line chart - Squash Commits in #542.

### DIFF
--- a/lib/morris.line.coffee
+++ b/lib/morris.line.coffee
@@ -319,10 +319,10 @@ class Morris.Line extends Morris.Grid
       @options.lineColors.call(@, row, sidx, type)
     else if type is 'point'
       @options.pointFillColors[sidx % @options.pointFillColors.length] || @options.lineColors[sidx % @options.lineColors.length]
-    else if type is 'line'
-      @options.lineColors[sidx % @options.lineColors.length]
-    else
+    else if type is 'trendLine'
       @options.trendLineColors[sidx % @options.trendLineColors.length]
+    else
+      @options.lineColors[sidx % @options.lineColors.length]
 
   drawXAxisLabel: (xPos, yPos, text) ->
     @raphael.text(xPos, yPos, text)


### PR DESCRIPTION
The line chart code always defaulted to using trendLineColors for
labels even when no trend lines were enabled.  This commit changes
that to use lineColors instead so that the labels match the lines
they are for.