### PR TITLE
Fix hover error when hovering over an empty bar chart

### DIFF
--- a/lib/morris.bar.coffee
+++ b/lib/morris.bar.coffee
@@ -238,7 +238,10 @@ class Morris.Bar extends Morris.Grid
   # @private
   onHoverMove: (x, y) =>
     index = @hitTest(x, y)
-    @hover.update(@hoverContentForRow(index)...)
+    if index?
+      @hover.update(@hoverContentForRow(index)...)
+    else
+      @hover.hide()
 
   # hover out event handler
   #


### PR DESCRIPTION
It caused an error trying to get that that didn't exist.