### PR TITLE
Prevent printing hover legend

### DIFF
--- a/morris.css
+++ b/morris.css
@@ -1,2 +1,3 @@
 .morris-hover{position:absolute;z-index:1000}.morris-hover.morris-default-style{border-radius:10px;padding:6px;color:#666;background:rgba(255,255,255,0.8);border:solid 2px rgba(230,230,230,0.8);font-family:sans-serif;font-size:12px;text-align:center}.morris-hover.morris-default-style .morris-hover-row-label{font-weight:bold;margin:0.25em 0}
 .morris-hover.morris-default-style .morris-hover-point{white-space:nowrap;margin:0.1em 0}
+@media print { .morris-hover{ display:none; } }


### PR DESCRIPTION
Hello,

I need to print reports in my current project. I noticed that if the hover legend is displayed on the chart when printing, it appears on the printed document and looks a bit sunsightly. So I think it is better to systematically hide it in printed document.