### PR TITLE
Added two new parameters for donut charts to set label font sizes

### DIFF
--- a/lib/morris.donut.coffee
+++ b/lib/morris.donut.coffee
@@ -24,6 +24,8 @@ class Morris.Donut extends Morris.EventEmitter
     ],
     backgroundColor: '#FFFFFF', 
     labelColor: '#000000',
+    labelMainSize: 15,
+    labelValueSize: 14,
     formatter: Morris.commas
     resize: false
 
@@ -85,8 +87,8 @@ class Morris.Donut extends Morris.EventEmitter
       last = next
       idx += 1
 
-    @text1 = @drawEmptyDonutLabel(cx, cy - 10, @options.labelColor, 15, 800)
-    @text2 = @drawEmptyDonutLabel(cx, cy + 10, @options.labelColor, 14)
+    @text1 = @drawEmptyDonutLabel(cx, cy - 10, @options.labelColor, @options.labelMainSize, 800)
+    @text2 = @drawEmptyDonutLabel(cx, cy + 10, @options.labelColor, @options.labelValueSize)
 
     max_value = Math.max @values...
     idx = 0

--- a/spec/lib/donut/donut_spec.coffee
+++ b/spec/lib/donut/donut_spec.coffee
@@ -74,3 +74,18 @@ describe 'Morris.Donut', ->
         { label: 'Three', value: 35 }
       ]
       $('#graph').find("path[stroke='#0000ff']").size().should.equal 1
+
+  describe 'changeLabelSizes', ->
+    defaults =
+      element: 'graph'
+      data: [ {label: 'One', value: 25 }, {label: "Two", value: 75} ]
+      labelMainSize: 8
+      labelValueSize: 10
+
+    it 'should have a label with font size 8', ->
+      chart = Morris.Donut $.extend {}, defaults
+      $('#graph').find("text[font-size='8px']").size().should.equal 1
+
+    it 'should have a label with font size 10', ->
+      chart = Morris.Donut $.extend {}, defaults
+      $('#graph').find("text[font-size='10px']").size().should.equal 1


### PR DESCRIPTION
Modifying the input parameters for the donut chart to allow two new parameters: labelMainSize, labelValueSize. This allows us to set the donut main label and value label sizes to n px. The default will be 15px,14px respectively. Also added new test for this.