### PR TITLE
Update morris.js

### DIFF
--- a/morris.css
+++ b/morris.css
@@ -1,2 +1,62 @@
 .morris-hover{position:absolute;z-index:1000}.morris-hover.morris-default-style{border-radius:10px;padding:6px;color:#666;background:rgba(255,255,255,0.8);border:solid 2px rgba(230,230,230,0.8);font-family:sans-serif;font-size:12px;text-align:center}.morris-hover.morris-default-style .morris-hover-row-label{font-weight:bold;margin:0.25em 0}
 .morris-hover.morris-default-style .morris-hover-point{white-space:nowrap;margin:0.1em 0}
+
+
+path.morris-line {
+  stroke-dasharray:5000;
+						  stroke-dashoffset:0;
+						   animation: dash 10s linear;
+						   animation-iteration-count: 1;
+-moz-animation-iteration-count: 1;
+-webkit-animation-iteration-count: 1;
+-o-animation-iteration-count: 1;
+}
+
+
+@keyframes dash {
+  from {
+    stroke-dashoffset: 5000;
+  } 
+}
+
+
+circle.morris-line-point {
+ animation: fadeEnter 2s linear;
+animation-iteration-count: 1;
+-moz-animation-iteration-count: 1;
+-webkit-animation-iteration-count: 1;
+-o-animation-iteration-count: 1;
+}
+
+@keyframes fadeEnter {
+  from {
+    opacity: 0;
+  } 
+  to {
+  opacity: 1
+  }
+}
+
+.morris-hover  {	
+ animation: popUp .2s linear;
+animation-iteration-count: 1;
+-moz-animation-iteration-count: 1;
+-webkit-animation-iteration-count: 1;
+-o-animation-iteration-count: 1;
+}
+
+@keyframes popUp {
+    0% {
+        transform: scale(.3);
+    }
+     0% {
+        transform: scale(1.3);
+    }
+    100% {
+        transform: scale(1);
+    }
+}
+
+
+
+

--- a/morris.js
+++ b/morris.js
@@ -1246,11 +1246,11 @@ Licensed under the BSD-2-Clause License.
     };
 
     Line.prototype.drawLinePath = function(path, lineColor, lineIndex) {
-      return this.raphael.path(path).attr('stroke', lineColor).attr('stroke-width', this.lineWidthForSeries(lineIndex));
+      return this.raphael.path(path).attr('stroke', lineColor).attr('stroke-width', this.lineWidthForSeries(lineIndex)).attr('class','morris-line');
     };
 
     Line.prototype.drawLinePoint = function(xPos, yPos, pointColor, lineIndex) {
-      return this.raphael.circle(xPos, yPos, this.pointSizeForSeries(lineIndex)).attr('fill', pointColor).attr('stroke-width', this.pointStrokeWidthForSeries(lineIndex)).attr('stroke', this.pointStrokeColorForSeries(lineIndex));
+      return this.raphael.circle(xPos, yPos, this.pointSizeForSeries(lineIndex)).attr('fill', pointColor).attr('stroke-width', this.pointStrokeWidthForSeries(lineIndex)).attr('stroke', this.pointStrokeColorForSeries(lineIndex)).attr('class','morris-line-point');
     };
 
     Line.prototype.pointStrokeWidthForSeries = function(index) {

--- a/morris.js
+++ b/morris.js
@@ -236,16 +236,7 @@ Licensed under the BSD-2-Clause License.
               ret.label = new Date(ret.label).toString();
             }
           } else {
-        	  if(this.options.valueFormatter) {
-        		  ret.src.formated = []
-        		  for(var ykey in this.options.ykeys) {
-        			  var value = ret.src[this.options.ykeys[ykey]];
-        			  ret.src.formated[this.options.ykeys[ykey]] =  this.options.valueFormatter(value);
-        	  } 
-        	  }
-        		  ret.x = index;
-        	  
-           
+        	 ret.x = index;
             if (this.options.xLabelFormat) {
               ret.label = this.options.xLabelFormat(ret);
             }
@@ -1840,6 +1831,7 @@ Licensed under the BSD-2-Clause License.
       maxRadius = Math.max.apply(Math, radiusArray);
       if (maxRadius === 0 || maxRadius > height) {
         path = this.raphael.rect(xPos, yPos, width, height);
+ 
       } else {
         path = this.raphael.path(this.roundedRect(xPos, yPos, width, height, radiusArray));
       }

--- a/morris.js
+++ b/morris.js
@@ -236,7 +236,16 @@ Licensed under the BSD-2-Clause License.
               ret.label = new Date(ret.label).toString();
             }
           } else {
-            ret.x = index;
+        	  if(this.options.valueFormatter) {
+        		  ret.src.formated = []
+        		  for(var ykey in this.options.ykeys) {
+        			  var value = ret.src[this.options.ykeys[ykey]];
+        			  ret.src.formated[this.options.ykeys[ykey]] =  this.options.valueFormatter(value);
+        	  } 
+        	  }
+        		  ret.x = index;
+        	  
+           
             if (this.options.xLabelFormat) {
               ret.label = this.options.xLabelFormat(ret);
             }
@@ -950,7 +959,7 @@ Licensed under the BSD-2-Clause License.
         if (this.options.labels[j] === false) {
           continue;
         }
-        content += "<div class='morris-hover-point' style='color: " + (this.colorFor(row, j, 'label')) + "'>\n  " + this.options.labels[j] + ":\n  " + (this.yLabelFormat(y, j)) + "\n</div>";
+        content += "<div class='morris-hover-point' style='color: " + (this.colorFor(row, j, 'label')) + "'>\n  " + this.options.labels[j] + ":\n  " + ( this.options.valueFormatter?this.options.valueFormatter (y): this.yLabelFormat(y, j)) + "\n</div>";
       }
       if (typeof this.options.hoverCallback === 'function') {
         content = this.options.hoverCallback(index, this.options, content, row.src);
@@ -1806,7 +1815,7 @@ Licensed under the BSD-2-Clause License.
         if (this.options.labels[j] === false) {
           continue;
         }
-        content += "<div class='morris-hover-point' style='color: " + (this.colorFor(row, j, 'label')) + "'>\n  " + this.options.labels[j] + ":\n  " + (this.yLabelFormat(y, j)) + "\n</div>";
+        content += "<div class='morris-hover-point' style='color: " + (this.colorFor(row, j, 'label')) + "'>\n  " + this.options.labels[j] + ":\n  " + (this.options.valueFormatter?this.options.valueFormatter (y):this.yLabelFormat(y, j)) + "\n</div>";
       }
       if (typeof this.options.hoverCallback === 'function') {
         content = this.options.hoverCallback(index, this.options, content, row.src);


### PR DESCRIPTION
Hi everyone
Something i missed and thus i tried to make it possible with morris was to format the number as is being shown in the chart.
Ex as a brazilian we use offten comma instead of dot to separate numbers.
This way i ca leave my chart to 'organize' the data with the normal number, ex: 1146.4 and when i need the user to see, it sees 1.146,40;

It just add a option called valueFormatter, that formatter onli the Y value(in my case i just needed it)
so i use add:


```
...
  parseTime: false,
  smooth: false,
  valueFormatter: function(value) {
       var negative = value < 0;                    		
       var valor = Math.abs(value);
       var final = valor.toFixed(2).replace('.', ',').replace(/(\d)(?=(\d{3})+\,)/g, "$1.");
      final = negative ? '-'+final:final;
       return final;
}
...

```

and the my value show as: 
![exemplo](https://user-images.githubusercontent.com/6757777/41489608-9950a994-70be-11e8-9575-fa91464edca2.png)
